### PR TITLE
LIBRETRO: allow selecting the pointer device in core options

### DIFF
--- a/backends/platform/libretro/README.md
+++ b/backends/platform/libretro/README.md
@@ -59,6 +59,7 @@ Operation status will be shown in the same dialog, while details will be given i
 
 ## Core options
 ### Cursor Movement
+  - **Pointer Device**: allows switching which device to use to move the cursor.
   - **Exclusive cursor control with RetroPad**: allows the use of RetroPad only to control mouse cursor, excluding the other inputs (e.g. physical mouse, touch screen).
   - **Gamepad Cursor Speed**: sets the mouse cursor speed multiplier when moving the cursor with the RetroPad left analog stick or D-Pad. The default value of '1.0' is optimised for games that have a native resolution of '320x200' or '320x240'. When running 'high definition' games with a resolution of '640x400' or '640x480', a Gamepad Cursor Speed of '2.0' is recommended.
   - **Gamepad Cursor Acceleration**: the amount of time (In seconds) it takes for the cursor to reach full speed

--- a/backends/platform/libretro/include/libretro-core-options.h
+++ b/backends/platform/libretro/include/libretro-core-options.h
@@ -97,6 +97,21 @@ struct retro_core_option_v2_category option_cats_us[] = {
 
 struct retro_core_option_v2_definition option_defs_us[] = {
 	{
+		"scummvm_pointer_device",
+		"Cursor > Pointer Device",
+		"Pointer Device",
+		"Select which device to control the pointer.",
+		NULL,
+		"cursor",
+		{
+			{"default", "Default"},
+			{"pointer", "Pointer"},
+			{"mouse", "Mouse"},
+			{NULL, NULL},
+		},
+		"default"
+	},
+	{
 		"scummvm_gamepad_cursor_only",
 		"Cursor > Exclusive cursor control with RetroPad",
 		"Exclusive cursor control with RetroPad",

--- a/backends/platform/libretro/include/libretro-core.h
+++ b/backends/platform/libretro/include/libretro-core.h
@@ -41,6 +41,15 @@ int retro_setting_get_mouse_fine_control_speed_reduction(void);
 bool retro_setting_get_gamepad_cursor_only(void);
 float retro_setting_get_gamepad_cursor_speed(void);
 float retro_setting_get_gamepad_acceleration_time(void);
+
+/**
+ * Retrieves the desired mouse pointer device.
+ *
+ * @return An integer representing which input device to use for the pointer:
+ *    - RETRO_DEVICE_MOUSE
+ *    - RETRO_DEVICE_POINTER
+ */
+int retro_setting_get_pointer_device(void);
 int retro_setting_get_gui_res_w(void);
 int retro_setting_get_gui_res_h(void);
 

--- a/backends/platform/libretro/src/libretro-core.cpp
+++ b/backends/platform/libretro/src/libretro-core.cpp
@@ -609,7 +609,7 @@ int retro_setting_get_pointer_device(void) {
 #if defined(WIIU) || defined(__SWITCH__)
 		return RETRO_DEVICE_POINTER;
 #else
-		return RETRO_DEVICE_MOUSE
+		return RETRO_DEVICE_MOUSE;
 #endif
 	}
 	return pointer_device;

--- a/backends/platform/libretro/src/libretro-core.cpp
+++ b/backends/platform/libretro/src/libretro-core.cpp
@@ -75,6 +75,7 @@ static bool gamepad_cursor_only = false;
 static float mouse_speed = 1.0f;
 static float gamepad_acceleration_time = 0.2f;
 static int mouse_fine_control_speed_reduction = 4;
+static int pointer_device = RETRO_DEVICE_NONE; // default pointer/mouse device
 
 char cmd_params[20][200];
 char cmd_params_num;
@@ -259,6 +260,16 @@ void retro_osd_notification(const char *msg) {
 static void update_variables(void) {
 	struct retro_variable var;
 	updating_variables = true;
+
+	var.key = "scummvm_pointer_device";
+	var.value = NULL;
+	pointer_device = RETRO_DEVICE_NONE;
+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+		if (strcmp(var.value, "mouse") == 0)
+			pointer_device = RETRO_DEVICE_MOUSE;
+		else if (strcmp(var.value, "pointer") == 0)
+			pointer_device = RETRO_DEVICE_POINTER;
+	}
 
 	var.key = "scummvm_gamepad_cursor_only";
 	var.value = NULL;
@@ -591,6 +602,17 @@ int retro_setting_get_mouse_fine_control_speed_reduction(void) {
 
 float retro_setting_get_gamepad_acceleration_time(void) {
 	return gamepad_acceleration_time;
+}
+
+int retro_setting_get_pointer_device(void) {
+	if (pointer_device == RETRO_DEVICE_NONE) {
+#if defined(WIIU) || defined(__SWITCH__)
+		return RETRO_DEVICE_POINTER;
+#else
+		return RETRO_DEVICE_MOUSE
+#endif
+	}
+	return pointer_device;
 }
 
 float retro_setting_get_frame_rate(void) {

--- a/backends/platform/libretro/src/libretro-os-inputs.cpp
+++ b/backends/platform/libretro/src/libretro-os-inputs.cpp
@@ -213,49 +213,49 @@ void OSystem_libretro::processInputs(void) {
 	if (retro_setting_get_gamepad_cursor_only())
 		return;
 
-#if defined(WIIU) || defined(__SWITCH__)
-	int p_x = retro_input_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
-	int p_y = retro_input_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
-	int p_press = retro_input_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
-	int px = (int)((p_x + 0x7fff) * getScreenWidth() / 0xffff);
-	int py = (int)((p_y + 0x7fff) * getScreenHeight() / 0xffff);
+	if (retro_setting_get_pointer_device() == RETRO_DEVICE_POINTER) {
+		int p_x = retro_input_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
+		int p_y = retro_input_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
+		int p_press = retro_input_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
+		int px = (int)((p_x + 0x7fff) * getScreenWidth() / 0xffff);
+		int py = (int)((p_y + 0x7fff) * getScreenHeight() / 0xffff);
 
-	static int ptrhold = 0;
+		static int ptrhold = 0;
 
-	if (p_press)
-		ptrhold++;
-	else
-		ptrhold = 0;
+		if (p_press)
+			ptrhold++;
+		else
+			ptrhold = 0;
 
-	if (ptrhold > 0) {
-		_mouseX = px;
-		_mouseY = py;
+		if (ptrhold > 0) {
+			_mouseX = px;
+			_mouseY = py;
 
-		Common::Event ev;
-		ev.type = Common::EVENT_MOUSEMOVE;
-		ev.mouse.x = _mouseX;
-		ev.mouse.y = _mouseY;
-		_events.push_back(ev);
-		setMousePosition(_mouseX, _mouseY);
+			Common::Event ev;
+			ev.type = Common::EVENT_MOUSEMOVE;
+			ev.mouse.x = _mouseX;
+			ev.mouse.y = _mouseY;
+			_events.push_back(ev);
+			setMousePosition(_mouseX, _mouseY);
+		}
+
+		if (ptrhold > 10 && _ptrmouseButton == 0) {
+			_ptrmouseButton = 1;
+			Common::Event ev;
+			ev.type = eventID[0][_ptrmouseButton ? 0 : 1];
+			ev.mouse.x = _mouseX;
+			ev.mouse.y = _mouseY;
+			_events.push_back(ev);
+		} else if (ptrhold == 0 && _ptrmouseButton == 1) {
+			_ptrmouseButton = 0;
+			Common::Event ev;
+			ev.type = eventID[0][_ptrmouseButton ? 0 : 1];
+			ev.mouse.x = _mouseX;
+			ev.mouse.y = _mouseY;
+			_events.push_back(ev);
+		}
+		return;
 	}
-
-	if (ptrhold > 10 && _ptrmouseButton == 0) {
-		_ptrmouseButton = 1;
-		Common::Event ev;
-		ev.type = eventID[0][_ptrmouseButton ? 0 : 1];
-		ev.mouse.x = _mouseX;
-		ev.mouse.y = _mouseY;
-		_events.push_back(ev);
-	} else if (ptrhold == 0 && _ptrmouseButton == 1) {
-		_ptrmouseButton = 0;
-		Common::Event ev;
-		ev.type = eventID[0][_ptrmouseButton ? 0 : 1];
-		ev.mouse.x = _mouseX;
-		ev.mouse.y = _mouseY;
-		_events.push_back(ev);
-	}
-
-#endif
 
 	// Process input from physical mouse
 	x = retro_input_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);


### PR DESCRIPTION
This is an initial attempt at adding a Pointer Device core option to allow selecting between...

- Default: The pointer device selected for the platform
- Mouse: The RetroMouse
- Pointer: Absolute pixel mouse usage

I haven't been able to compile this on my local machine yet.

Fixes #96 
