### PR TITLE
LIBRETRO: BUILD: add a Linux aarch64 build

### DIFF
--- a/backends/platform/libretro/.gitlab-ci.yml
+++ b/backends/platform/libretro/.gitlab-ci.yml
@@ -30,6 +30,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -135,6 +139,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of ScummVM, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: ScummVM is portable C++ with no x86-specific code on this path, and `android-arm64-v8a` already builds these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include, both in `backends/platform/libretro/.gitlab-ci.yml` (the repository-root `.gitlab-ci.yml` only includes that file).

Verified natively on aarch64 (postmarketOS on a Snapdragon 670 Chromebook, glibc, GCC 15): `make platform=unix` in `backends/platform/libretro` builds the full core with no source changes and without a single error across all enabled engines - 8767 objects, linking to `scummvm_libretro.so` (ELF 64-bit ARM aarch64, 155 MB unstripped). I didn't run a game through it in this session, so this is a build verification.
