### PR TITLE
Add frontend VFS support

### DIFF
--- a/backends/platform/libretro/Makefile.common
+++ b/backends/platform/libretro/Makefile.common
@@ -271,6 +271,8 @@ MODULE_PATHS += $(CORE_PATH)
 
 LIBRETRO_OBJS := $(CORE_PATH)/libretro-core.o \
 	$(CORE_PATH)/libretro-fs.o \
+	$(CORE_PATH)/libretro-stream.o \
+	$(CORE_PATH)/libretro-vfs.o \
 	$(CORE_PATH)/libretro-fs-factory.o \
 	$(CORE_PATH)/libretro-os-base.o \
 	$(CORE_PATH)/libretro-os-events.o \

--- a/backends/platform/libretro/include/libretro-fs.h
+++ b/backends/platform/libretro/include/libretro-fs.h
@@ -24,6 +24,8 @@
 
 #include "backends/fs/abstract-fs.h"
 
+#include <file/file_path.h>
+
 #ifdef MACOSX
 #include <sys/types.h>
 #endif
@@ -61,7 +63,7 @@ public:
 	LibRetroFilesystemNode(const Common::String &path);
 
 	virtual bool exists() const {
-		return access(_path.c_str(), F_OK) == 0;
+		return path_is_valid(_path.c_str());
 	}
 	virtual Common::U32String getDisplayName() const {
 		return _displayName;
@@ -96,6 +98,12 @@ private:
 	 * Tests and sets the _isValid and _isDirectory flags, using the stat() function.
 	 */
 	virtual void setFlags();
+
+	/**
+	 * Appends the locations the frontend granted access to (which are not
+	 * reachable from the local file system root) to the given list.
+	 */
+	void addAuthorizedLocations(AbstractFSList &myList) const;
 };
 
 #endif

--- a/backends/platform/libretro/include/libretro-stream.h
+++ b/backends/platform/libretro/include/libretro-stream.h
@@ -1,0 +1,77 @@
+/* Copyright (C) 2023 Giovanni Cascione <ing.cascione@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef LIBRETRO_STREAM_H
+#define LIBRETRO_STREAM_H
+
+#include "common/scummsys.h"
+#include "common/noncopyable.h"
+#include "common/stream.h"
+#include "common/str.h"
+
+/**
+ * Stream based on libretro-common's filestream API, which routes file access
+ * through the frontend VFS interface whenever one has been negotiated (see
+ * retro_init_vfs()) and falls back to the local file system otherwise.
+ *
+ * It is the counterpart of StdioStream, which cannot be used here as it always
+ * goes through stdio, bypassing the frontend.
+ */
+class LibRetroStream : public Common::SeekableReadStream, public Common::SeekableWriteStream, public Common::NonCopyable {
+public:
+	enum WriteMode {
+		WriteMode_Read = 0,
+		WriteMode_Write = 1,
+		WriteMode_WriteAtomic = 2,
+	};
+
+	/**
+	 * Opens the given path and wraps the result in a LibRetroStream instance.
+	 *
+	 * @param path the file to open.
+	 * @param writeMode how the file is to be accessed. In atomic mode the data
+	 * is written to a temporary file, which is renamed on stream destruction.
+	 *
+	 * @return the stream, or nullptr if the file could not be opened.
+	 */
+	static LibRetroStream *makeFromPath(const Common::String &path, WriteMode writeMode);
+
+	LibRetroStream(struct RFILE *handle);
+	~LibRetroStream() override;
+
+	bool err() const override;
+	void clearErr() override;
+	bool eos() const override;
+
+	uint32 write(const void *dataPtr, uint32 dataSize) override;
+	bool flush() override;
+
+	int64 pos() const override;
+	int64 size() const override;
+	bool seek(int64 offs, int whence = SEEK_SET) override;
+	uint32 read(void *dataPtr, uint32 dataSize) override;
+
+private:
+	/** File handle to the actual file. */
+	struct RFILE *_handle;
+	/** Final path of a file opened in atomic mode, nullptr otherwise. */
+	Common::String *_path;
+	bool _err;
+	bool _eos;
+};
+
+#endif // LIBRETRO_STREAM_H

--- a/backends/platform/libretro/include/libretro-vfs.h
+++ b/backends/platform/libretro/include/libretro-vfs.h
@@ -1,0 +1,78 @@
+/* Copyright (C) 2023 Giovanni Cascione <ing.cascione@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef LIBRETRO_VFS_H
+#define LIBRETRO_VFS_H
+
+#include <libretro.h>
+
+#include "common/array.h"
+#include "common/str.h"
+
+/**
+ * Locations the frontend has been granted access to (e.g. SAF trees on
+ * Android), as returned by RETRO_ENVIRONMENT_GET_VFS_AUTHORIZED_LOCATIONS.
+ * Defined here as long as the bundled libretro.h predates that environment
+ * call.
+ */
+#ifndef RETRO_ENVIRONMENT_GET_VFS_AUTHORIZED_LOCATIONS
+#define RETRO_ENVIRONMENT_GET_VFS_AUTHORIZED_LOCATIONS (93 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+
+struct retro_vfs_authorized_location {
+	const char *path;
+	const char *label;
+	unsigned flags;
+};
+
+struct retro_vfs_authorized_locations {
+	const struct retro_vfs_authorized_location *locations;
+	size_t count;
+};
+#endif
+
+struct LibRetroVfsLocation {
+	Common::String path;
+	Common::String label;
+};
+
+/**
+ * Requests the frontend file system interface and hooks it into the
+ * libretro-common filestream/dirent/path wrappers used by the file system
+ * backend. If the frontend provides no (or a too old) interface, those
+ * wrappers keep using their built-in local file system implementation.
+ *
+ * Must be called from retro_set_environment(), i.e. before the ScummVM
+ * file system factory is instantiated.
+ */
+void retro_init_vfs(retro_environment_t cb);
+
+/**
+ * @return Whether file access is routed through the frontend VFS interface.
+ */
+bool retro_vfs_enabled(void);
+
+/**
+ * Retrieves the locations the frontend granted access to. The list is queried
+ * on each call, as the user may authorize further locations while the core is
+ * running.
+ *
+ * @return The authorized locations, empty if the frontend has none or does not
+ * support the related environment call.
+ */
+Common::Array<LibRetroVfsLocation> retro_get_authorized_locations(void);
+
+#endif // LIBRETRO_VFS_H

--- a/backends/platform/libretro/src/libretro-core.cpp
+++ b/backends/platform/libretro/src/libretro-core.cpp
@@ -55,6 +55,7 @@
 #include "backends/platform/libretro/include/libretro-core-options.h"
 #include "backends/platform/libretro/include/libretro-os.h"
 #include "backends/platform/libretro/include/libretro-mapper.h"
+#include "backends/platform/libretro/include/libretro-vfs.h"
 
 static struct retro_game_info game_buf;
 static struct retro_game_info *game_buf_ptr;
@@ -797,6 +798,8 @@ void retro_set_environment(retro_environment_t cb) {
 	bool tmp = true;
 	bool has_categories;
 	environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &tmp);
+	/* Has to be set up before the file system factory is instantiated */
+	retro_init_vfs(environ_cb);
 	libretro_fill_options_mapper_data(environ_cb);
 	libretro_set_core_options(environ_cb, &has_categories);
 

--- a/backends/platform/libretro/src/libretro-fs.cpp
+++ b/backends/platform/libretro/src/libretro-fs.cpp
@@ -37,16 +37,79 @@
 #include <stdio.h>
 
 #include "backends/platform/libretro/include/libretro-fs.h"
-#include "backends/fs/stdiostream.h"
+#include "backends/platform/libretro/include/libretro-stream.h"
+#include "backends/platform/libretro/include/libretro-vfs.h"
 #include "common/algorithm.h"
+#include "common/util.h"
+
+/**
+ * Frontend VFS paths may be URIs (e.g. saf://<tree>/dir/file on Android)
+ * rather than plain file system paths. Their scheme must be kept out of any
+ * path manipulation, as normalizing it would collapse the "//" separator.
+ *
+ * @return the length of the "scheme://" prefix, 0 if the path has none.
+ */
+static uint uriSchemeLength(const Common::String &path) {
+	uint i;
+
+	for (i = 0; i < path.size(); i++) {
+		const char c = path[i];
+
+		if (Common::isAlnum(c) || c == '+' || c == '-' || c == '.')
+			continue;
+
+		// A scheme must not be empty and is followed by "://"
+		return (i > 0 && !strncmp(path.c_str() + i, "://", 3)) ? i + 3 : 0;
+	}
+
+	return 0;
+}
+
+/**
+ * Normalizes a path, leaving any URI scheme prefix untouched.
+ */
+static Common::String normalizeRetroPath(const Common::String &path) {
+	const uint schemeLength = uriSchemeLength(path);
+
+	if (!schemeLength)
+		return Common::normalizePath(path, '/');
+
+	return Common::String(path.c_str(), schemeLength) + Common::normalizePath(Common::String(path.c_str() + schemeLength), '/');
+}
+
+/**
+ * Returns the offset of the first path component below the root of the given
+ * path, i.e. the point up to which getParent() may strip components. For URIs
+ * the root is the scheme along with the location it refers to (e.g. the SAF
+ * tree), which cannot be split any further.
+ */
+static uint rootLength(const Common::String &path) {
+	uint i = uriSchemeLength(path);
+
+	if (!i)
+		return 1; // "/"
+
+	while (i < path.size() && path[i] != '/')
+		i++;
+
+	return i;
+}
 
 void LibRetroFilesystemNode::setFlags() {
 	const char *fspath = _path.c_str();
 
 	_isValid = path_is_valid(fspath);
 	_isDirectory = path_is_directory(fspath);
-	_isReadable = access(fspath, R_OK) == 0;
-	_isWritable = access(_path.c_str(), W_OK) == 0;
+
+	if (retro_vfs_enabled()) {
+		// The VFS interface reports no permissions, assume whatever the
+		// frontend hands out can be both read and written.
+		_isReadable = _isValid;
+		_isWritable = _isValid;
+	} else {
+		_isReadable = access(fspath, R_OK) == 0;
+		_isWritable = access(fspath, W_OK) == 0;
+	}
 }
 
 LibRetroFilesystemNode::LibRetroFilesystemNode(const Common::String &p) {
@@ -69,8 +132,9 @@ LibRetroFilesystemNode::LibRetroFilesystemNode(const Common::String &p) {
 	strcpy(portable_path, _path.c_str());
 	pathname_make_slashes_portable(portable_path);
 
-	// Normalize the path (that is, remove unneeded slashes etc.)
-	_path = Common::normalizePath(Common::String(portable_path), '/');
+	// Normalize the path (that is, remove unneeded slashes etc.), keeping any
+	// URI scheme of a frontend VFS path intact
+	_path = normalizeRetroPath(Common::String(portable_path));
 	_displayName = Common::lastPathComponent(_path, '/');
 
 	setFlags();
@@ -137,12 +201,49 @@ bool LibRetroFilesystemNode::getChildren(AbstractFSList &myList, ListMode mode, 
 	}
 	retro_closedir(dirp);
 
+	if (mode != Common::FSNode::kListFilesOnly && _path == "/")
+		addAuthorizedLocations(myList);
+
 	return true;
+}
+
+void LibRetroFilesystemNode::addAuthorizedLocations(AbstractFSList &myList) const {
+	// Locations the frontend granted access to (e.g. SAF trees on Android)
+	// live outside of the local file system hierarchy, hence they are exposed
+	// as additional children of the root node to make them browsable.
+	Common::Array<LibRetroVfsLocation> locations = retro_get_authorized_locations();
+	Common::StringArray usedNames;
+
+	for (uint i = 0; i < locations.size(); i++) {
+		LibRetroFilesystemNode entry(locations[i].path);
+
+		if (!entry._isValid || !entry._isDirectory)
+			continue;
+
+		if (!locations[i].label.empty())
+			entry._displayName = locations[i].label;
+
+		// Frontends may label several locations the same way (e.g. all SAF
+		// trees on Android), make sure each entry is distinguishable
+		Common::String name(entry._displayName);
+		for (uint n = 2; Common::find(usedNames.begin(), usedNames.end(), entry._displayName) != usedNames.end(); n++)
+			entry._displayName = Common::String::format("%s (%u)", name.c_str(), n);
+
+		usedNames.push_back(entry._displayName);
+		myList.push_back(new LibRetroFilesystemNode(entry));
+	}
 }
 
 AbstractFSNode *LibRetroFilesystemNode::getParent() const {
 	if (_path == "/")
 		return 0; // The filesystem root has no parent
+
+	const uint root = rootLength(_path);
+
+	// A frontend VFS location cannot be split any further: its parent is the
+	// root node, which lists all of them along with the local file system
+	if (_path.size() <= root)
+		return makeNode("/");
 
 	const char *start = _path.c_str();
 	const char *end = start + _path.size();
@@ -156,6 +257,9 @@ AbstractFSNode *LibRetroFilesystemNode::getParent() const {
 		return 0;
 	}
 
+	if ((uint)(end - start) <= root)
+		return makeNode(Common::String(start, root));
+
 	AbstractFSNode *parent = makeNode(Common::String(start, end));
 
 	if (parent->isDirectory() == false)
@@ -165,11 +269,11 @@ AbstractFSNode *LibRetroFilesystemNode::getParent() const {
 }
 
 Common::SeekableReadStream *LibRetroFilesystemNode::createReadStream() {
-	return StdioStream::makeFromPath(getPath(), StdioStream::WriteMode_Read);
+	return LibRetroStream::makeFromPath(getPath(), LibRetroStream::WriteMode_Read);
 }
 
 Common::SeekableWriteStream *LibRetroFilesystemNode::createWriteStream(bool atomic) {
-	return StdioStream::makeFromPath(getPath(), atomic ? StdioStream::WriteMode_WriteAtomic : StdioStream::WriteMode_Write);
+	return LibRetroStream::makeFromPath(getPath(), atomic ? LibRetroStream::WriteMode_WriteAtomic : LibRetroStream::WriteMode_Write);
 }
 
 bool LibRetroFilesystemNode::createDirectory() {
@@ -201,11 +305,13 @@ bool assureDirectoryExists(const Common::String &dir, const char *prefix) {
 		path = dir;
 	}
 
-	path = Common::normalizePath(path, '/');
+	path = normalizeRetroPath(path);
 
 	const Common::String::iterator end = path.end();
-	Common::String::iterator cur = path.begin();
-	if (*cur == '/')
+	// Skip the root: neither "/" nor a frontend VFS location (whose scheme
+	// would be mangled by the loop below) can be created
+	Common::String::iterator cur = path.begin() + rootLength(path);
+	if (cur < end && *cur == '/')
 		++cur;
 
 	do {

--- a/backends/platform/libretro/src/libretro-options-widget.cpp
+++ b/backends/platform/libretro/src/libretro-options-widget.cpp
@@ -120,7 +120,7 @@ bool LibretroOptionsWidget::cleanFolder(Common::String &path) {
 		Common::FSNode *fshook = dynamic_cast<Common::FSNode *>(hook.get());
 		if (!fshook || fshook->isDirectory())
 			continue;
-		if (remove(fshook->getPath().toString().c_str()) == 0)
+		if (filestream_delete(fshook->getPath().toString().c_str()) == 0)
 			if (retro_log_cb)
 				retro_log_cb(RETRO_LOG_INFO, "Hook file deleted in '%s'.\n", fshook->getPath().toString().c_str());
 		else {

--- a/backends/platform/libretro/src/libretro-stream.cpp
+++ b/backends/platform/libretro/src/libretro-stream.cpp
@@ -1,0 +1,163 @@
+/* Copyright (C) 2023 Giovanni Cascione <ing.cascione@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
+#include <streams/file_stream.h>
+
+#include "backends/platform/libretro/include/libretro-stream.h"
+#include "common/textconsole.h"
+
+LibRetroStream::LibRetroStream(RFILE *handle) : _handle(handle), _path(nullptr), _err(false), _eos(false) {
+	assert(handle);
+}
+
+LibRetroStream::~LibRetroStream() {
+	filestream_close(_handle);
+
+	if (!_path)
+		return;
+
+	// _path is set: recreate the temporary file name and rename the file to
+	// its real name
+	Common::String tmpPath(*_path);
+	tmpPath += ".tmp";
+
+	if (filestream_rename(tmpPath.c_str(), _path->c_str())) {
+		// Error: try to delete the destination file first, as not all
+		// implementations replace an existing file on rename
+		filestream_delete(_path->c_str());
+
+		if (filestream_rename(tmpPath.c_str(), _path->c_str()))
+			warning("Couldn't save file %s", _path->c_str());
+	}
+
+	delete _path;
+}
+
+bool LibRetroStream::err() const {
+	return _err || filestream_error(_handle);
+}
+
+void LibRetroStream::clearErr() {
+	_err = false;
+	_eos = false;
+
+	if (!filestream_error(_handle))
+		return;
+
+	// filestream has no way to clear its own error flag, rewinding resets it
+	// along with the file position, so the current position is restored.
+	int64 oldPos = filestream_tell(_handle);
+	filestream_rewind(_handle);
+	if (oldPos > 0)
+		filestream_seek(_handle, oldPos, RETRO_VFS_SEEK_POSITION_START);
+}
+
+bool LibRetroStream::eos() const {
+	return _eos;
+}
+
+int64 LibRetroStream::pos() const {
+	return filestream_tell(_handle);
+}
+
+int64 LibRetroStream::size() const {
+	return filestream_get_size(_handle);
+}
+
+bool LibRetroStream::seek(int64 offs, int whence) {
+	int position;
+
+	switch (whence) {
+	case SEEK_CUR:
+		position = RETRO_VFS_SEEK_POSITION_CURRENT;
+		break;
+	case SEEK_END:
+		position = RETRO_VFS_SEEK_POSITION_END;
+		break;
+	case SEEK_SET:
+	default:
+		position = RETRO_VFS_SEEK_POSITION_START;
+		break;
+	}
+
+	if (filestream_seek(_handle, offs, position) < 0)
+		return false;
+
+	// As with stdio streams, seeking clears the end of stream condition
+	_eos = false;
+
+	return true;
+}
+
+uint32 LibRetroStream::read(void *dataPtr, uint32 dataSize) {
+	int64 bytesRead = filestream_read(_handle, dataPtr, dataSize);
+
+	if (bytesRead < 0) {
+		_err = true;
+		return 0;
+	}
+
+	if ((uint32)bytesRead < dataSize)
+		_eos = true;
+
+	return (uint32)bytesRead;
+}
+
+uint32 LibRetroStream::write(const void *dataPtr, uint32 dataSize) {
+	int64 bytesWritten = filestream_write(_handle, dataPtr, dataSize);
+
+	if (bytesWritten < 0) {
+		_err = true;
+		return 0;
+	}
+
+	if ((uint32)bytesWritten < dataSize)
+		_err = true;
+
+	return (uint32)bytesWritten;
+}
+
+bool LibRetroStream::flush() {
+	return filestream_flush(_handle) == 0;
+}
+
+LibRetroStream *LibRetroStream::makeFromPath(const Common::String &path, WriteMode writeMode) {
+	Common::String tmpPath(path);
+
+	// In atomic mode a temporary file is created and renamed when the stream
+	// is destroyed
+	if (writeMode == WriteMode_WriteAtomic)
+		tmpPath += ".tmp";
+
+	RFILE *handle = filestream_open(tmpPath.c_str(),
+	                                writeMode == WriteMode_Read ? RETRO_VFS_FILE_ACCESS_READ : RETRO_VFS_FILE_ACCESS_WRITE,
+	                                RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+	if (!handle)
+		return nullptr;
+
+	LibRetroStream *stream = new LibRetroStream(handle);
+
+	// Store the final path alongside the stream: if _path is not nullptr, it
+	// will be used to rename the file when closing it
+	if (writeMode == WriteMode_WriteAtomic)
+		stream->_path = new Common::String(path);
+
+	return stream;
+}

--- a/backends/platform/libretro/src/libretro-vfs.cpp
+++ b/backends/platform/libretro/src/libretro-vfs.cpp
@@ -1,0 +1,99 @@
+/* Copyright (C) 2023 Giovanni Cascione <ing.cascione@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define FORBIDDEN_SYMBOL_ALLOW_ALL
+
+#include <file/file_path.h>
+#include <retro_dirent.h>
+#include <streams/file_stream.h>
+
+#include "backends/platform/libretro/include/libretro-vfs.h"
+#include "backends/platform/libretro/include/libretro-core.h"
+
+/* Directory listing and stat/mkdir wrappers need VFS v3, streams need v2 only. */
+#define RETRO_VFS_WANTED_VERSION 3
+
+static retro_environment_t vfs_environ_cb = NULL;
+static bool vfs_enabled = false;
+
+void retro_init_vfs(retro_environment_t cb) {
+	struct retro_vfs_interface_info vfs_iface_info;
+
+	vfs_environ_cb = cb;
+	vfs_enabled = false;
+
+	if (!cb)
+		return;
+
+	vfs_iface_info.required_interface_version = RETRO_VFS_WANTED_VERSION;
+	vfs_iface_info.iface = NULL;
+
+	if (!cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info) || !vfs_iface_info.iface) {
+		if (retro_log_cb)
+			retro_log_cb(RETRO_LOG_INFO, "Frontend provides no VFS interface, using local file system.\n");
+		return;
+	}
+
+	/* The frontend reports back the version it actually implements: the
+	   init helpers below silently keep their built-in implementation if it
+	   is lower than what they need. */
+	filestream_vfs_init(&vfs_iface_info);
+	path_vfs_init(&vfs_iface_info);
+	dirent_vfs_init(&vfs_iface_info);
+
+	/* Streams are already routed through the frontend with v2, but the file
+	   system backend also needs the v3 stat/mkdir/directory calls to be able
+	   to browse frontend specific locations. */
+	vfs_enabled = vfs_iface_info.required_interface_version >= RETRO_VFS_WANTED_VERSION;
+
+	if (retro_log_cb)
+		retro_log_cb(vfs_enabled ? RETRO_LOG_INFO : RETRO_LOG_WARN,
+		             "Frontend VFS interface version %u found, VFS file system %s (version %d needed).\n",
+		             vfs_iface_info.required_interface_version, vfs_enabled ? "enabled" : "disabled", RETRO_VFS_WANTED_VERSION);
+}
+
+bool retro_vfs_enabled(void) {
+	return vfs_enabled;
+}
+
+Common::Array<LibRetroVfsLocation> retro_get_authorized_locations(void) {
+	Common::Array<LibRetroVfsLocation> retval;
+	struct retro_vfs_authorized_locations locations;
+
+	if (!vfs_enabled || !vfs_environ_cb)
+		return retval;
+
+	locations.locations = NULL;
+	locations.count = 0;
+
+	if (!vfs_environ_cb(RETRO_ENVIRONMENT_GET_VFS_AUTHORIZED_LOCATIONS, &locations) || !locations.locations)
+		return retval;
+
+	for (size_t i = 0; i < locations.count; i++) {
+		LibRetroVfsLocation location;
+
+		if (!locations.locations[i].path)
+			continue;
+
+		/* The frontend owns the strings, hence the copies. */
+		location.path = locations.locations[i].path;
+		location.label = locations.locations[i].label ? locations.locations[i].label : locations.locations[i].path;
+		retval.push_back(location);
+	}
+
+	return retval;
+}


### PR DESCRIPTION
Routes core file access through the frontend VFS instead of pinning it to the local file system, so frontend specific locations (SAF trees on Android, archives, network mounts) become reachable. Refs #88.

`retro_set_environment()` requests `RETRO_ENVIRONMENT_GET_VFS_INTERFACE` (v3) and hooks it into the libretro-common `filestream`, `path` and `dirent` wrappers the file system backend already uses; a new `LibRetroStream` replaces `StdioStream` for read, write and atomic write streams. Atomic write semantics are unchanged (write to `<name>.tmp`, rename on close), just through `filestream_rename()`. With no interface, or one below v3, everything falls back to the built-in local implementation as before.

Frontend paths may be URIs, which `Common::normalizePath()` would turn into `saf:/<tree>/...`, so `LibRetroFilesystemNode` keeps a `scheme://` prefix out of normalization, out of `getParent()` (a location cannot be split below the root the frontend authorized) and out of `Posix::assureDirectoryExists()`. `setFlags()` no longer uses POSIX `access()` when the frontend interface is in use, as VFS carries no permission bits.

Authorized locations are queried through `RETRO_ENVIRONMENT_GET_VFS_AUTHORIZED_LOCATIONS` (libretro/RetroArch#19347) and listed as children of the root node, since they live outside the local hierarchy and would not be browsable otherwise; identical frontend labels are numbered. The env call and its structs are defined locally as long as the bundled `libretro.h` predates them.

Built for `linux-aarch64` and exercised with two harnesses linked against the core objects: one on the local fallback (path handling, nested directory creation, read/write/seek/eos, atomic write and overwrite, listing), one end to end against a fake frontend exposing a VFS v3 interface with its own `test://` scheme (negotiation, authorized locations, mkdir, browsing, reading, atomic write with rename, root node listing). All checks pass, with file operations landing on the fake frontend rather than on stdio. Real SAF paths still need a RetroArch build carrying libretro/RetroArch#19347.
