### PR TITLE
LIBRETRO: exclude WebMIDI plugin

### DIFF
--- a/backends/module.mk
+++ b/backends/module.mk
@@ -103,9 +103,14 @@ MODULE_OBJS += \
 	fs/emscripten/emscripten-fs-factory.o \
 	fs/emscripten/emscripten-posix-fs.o \
 	fs/emscripten/http-fs.o \
-	midi/webmidi.o \
 	mixer/emscriptensdl/emscriptensdl-mixer.o \
 	timer/emscripten/emscripten-timer.o
+# midi/webmidi.o intentionally excluded: its EM_JS glue calls Module.setValue
+# and expects a midiOutputMap global from ScummVM's own standalone-Emscripten
+# shell (dists/emscripten/custom_shell-pre.js), neither of which this
+# RetroArch/EmulatorJS-based libretro-core build provides. Real MIDI hardware
+# output isn't needed here; ScummVM's other built-in music drivers are
+# unaffected.
 ifdef USE_CLOUD
 MODULE_OBJS += \
 	fs/emscripten/cloud-fs.o

--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -139,9 +139,7 @@ public:
 		LINK_PLUGIN(FLUIDSYNTH)
 		#endif
 
-		#ifdef EMSCRIPTEN
-		LINK_PLUGIN(WEBMIDI)
-		#endif
+		// WEBMIDI is deliberately not linked here; see backends/module.mk.
 		#ifdef USE_MT32EMU
 		LINK_PLUGIN(MT32)
 		#endif


### PR DESCRIPTION
`backends/midi/webmidi.cpp` is compiled in for any EMSCRIPTEN build, but its
`EM_JS` glue needs a `midiOutputMap` global and a `Module.setValue` export that
only ScummVM's own standalone shell (`dists/emscripten/custom_shell-pre.js`)
provides. Under RetroArch/EmulatorJS neither exists, so device enumeration
throws during engine startup.

Removes `midi/webmidi.o` from `backends/module.mk` and `LINK_PLUGIN(WEBMIDI)`
from `base/plugins.cpp` -- both are needed, the registration table being
independent of the object list.

Scope: both edits sit inside the existing `EMSCRIPTEN` guards, so no other
platform is affected. The core still reaches real MIDI through the frontend's
`RETRO_ENVIRONMENT_GET_MIDI_INTERFACE`, and the other music drivers are
untouched.