### PR TITLE
LIBRETRO: Log the unknown-game report when autodetection finds nothing

### DIFF
--- a/backends/platform/libretro/src/libretro-os-utils.cpp
+++ b/backends/platform/libretro/src/libretro-os-utils.cpp
@@ -136,6 +136,8 @@ int OSystem_libretro::testGame(const char *filedata, bool autodetect) {
 		if (!detectionResults.listRecognizedGames().empty()) {
 			res = TEST_GAME_OK_ID_AUTODETECTED;
 		}
+		if (detectionResults.foundUnknownGames())
+			logMessage(LogMessageType::kWarning, detectionResults.generateUnknownGameReport(false, 80).encode().c_str());
 
 	} else {
 


### PR DESCRIPTION
testGame() runs detection before --auto-detect ever does, so when nothing
matches, the unknown-game report is never produced and the user gets an
empty launcher with no clue which files did not match. Log the report the
Add Game dialog would have shown.